### PR TITLE
Adding back team_id into service

### DIFF
--- a/api/datastore.py
+++ b/api/datastore.py
@@ -11,15 +11,15 @@ class Mongodb:
     async def create_team(self, item, response_model):
         
         try:
-            team_found = await self.get_team("",item["team_name"])
+            team_found = await self.get_team("",item["name"])
             if team_found:
                 response_model.__dict__.update({"description" : "Team name already exists", "success" : False, "id" : ""})
                 return response_model
             else:
                 new_team = await self.db["teams"].insert_one(item)
-                team_id = item["id"]
-                created_team = await self.db["teams"].find_one({"id": team_id})
-                response_model.__dict__.update({"description" : "Team Created", "success" : True, "id" : str(team_id)})
+                id = item["id"]
+                created_team = await self.db["teams"].find_one({"id": id})
+                response_model.__dict__.update({"description" : "Team Created", "success" : True, "id" : str(id)})
                 return response_model
 
         except Exception as e:
@@ -29,15 +29,19 @@ class Mongodb:
 
     async def create_service(self, item, response_model):   
         try:
-            service_found = await self.get_service("",item["service_name"])
+            service_found = await self.get_service("",item["name"])
             if service_found:
                 response_model.__dict__.update({"description" : "Service name already exists", "success" : False, "id" : ""})
                 return response_model
             else:
+                team_found = await self.get_team(item["team_id"], "")
+                if team_found is None:
+                    response_model.__dict__.update({"description" : "Invalid team_id assigned to service", "success" : False, "id" : ""})
+                    return response_model
                 new_service = await self.db["services"].insert_one(item)
-                service_id = item["id"]
-                created_service = await self.db["services"].find_one({"id": service_id})
-                response_model.__dict__.update({"description" : "Service Created", "success" : True, "id" : str(service_id)})
+                id = item["id"]
+                created_service = await self.db["services"].find_one({"id": id})
+                response_model.__dict__.update({"description" : "Service Created", "success" : True, "id" : str(id)})
                 return response_model
 
         except Exception as e:
@@ -45,13 +49,13 @@ class Mongodb:
             raise e
             return response_model
         
-    async def get_team(self, team_id, team_name, response_model=None):
-        if team_id:
+    async def get_team(self, id, name, response_model=None):
+        if id:
             key = "id"
-            value = team_id
+            value = id
         else:
-            key = "team_name"
-            value = team_name
+            key = "name"
+            value = name
         try:
             found_team = await self.db["teams"].find_one({key: value})
             if response_model != None and (found_team):
@@ -64,13 +68,13 @@ class Mongodb:
             return response_model
             raise e
 
-    async def get_service(self, service_id, service_name, response_model=None):
-        if service_id:
+    async def get_service(self, id, name, response_model=None):
+        if id:
             key = "id"
-            value = service_id
+            value = id
         else:
-            key = "service_name"
-            value = service_name
+            key = "name"
+            value = name
         try:
             found_service = await self.db["services"].find_one({key: value})
         

--- a/api/routes.py
+++ b/api/routes.py
@@ -70,18 +70,18 @@ async def create_team(requested_team: CreateTeam):
         )
 
 @app.get("/get_team", response_model=Team)
-async def get_team(id: str=None, team_name: str=None):
+async def get_team(id: str=None, name: str=None):
     #t = GetModel
     team_data = {
         "id": id,
-        "team_name": team_name
+        "name": name
     }
 
     # Get Team Data
     client = Mongodb()
     response_mod = await client.get_team(
         id=team_data["id"],
-        team_name=team_data["team_name"],
+        name=team_data["name"],
         response_model=Team
     )
 
@@ -90,16 +90,16 @@ async def get_team(id: str=None, team_name: str=None):
     raise HTTPException(status_code=404, detail=f"Team not found")
 
 @app.get("/get_service", response_model=Service)
-async def get_service(id: str=None, service_name: str=None):
+async def get_service(id: str=None, name: str=None):
     service_data = {
         "id": id,
-        "service_name": service_name
+        "name": name
     }
 
     client = Mongodb()
     response_mod = await client.get_service(
         id=service_data["id"],
-        service_name=service_data["service_name"],
+        name=service_data["name"],
         response_model=Service
     )
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -5,24 +5,25 @@ from typing import Optional
 #   DEFINE BaseModels
 ##################
 class CreateService(BaseModel):
-    service_name: str
+    name: str
     pager_duty_link: str
-    service_id: str
+    team_id: str
 
 class CreateTeam(BaseModel):
-    team_name: str
+    name: str
     operator_group: str
     admin_group: str
     slack_channel: str
     
 class Service(BaseModel):
     id: str = ""
-    service_name: str = ""
+    name: str = ""
     pager_duty_link: str = ""
+    team_id = ""
 
 class Team(BaseModel):
     id: str = ""
-    team_name: str = ""
+    name: str = ""
     operator_group: str = ""
     admin_group: str = ""
     slack_channel: str = ""
@@ -33,6 +34,6 @@ class CreateModel(BaseModel):
     description: str = ""
 
 class DeleteModel(BaseModel):
+    id: str = ""
     success: bool = True
     description: str = ""
-    id: str = ""


### PR DESCRIPTION
I had absent mindedly removed the team_id from service in my PR to add delete.
This fixes that.
Also, I am making things have "id" and "name" rather than "team_id" and "team_name and "service_id" and "service_name" since if its part of a Service or Team object, we can infer what the "id" and "name" is for. Only in the Service object do we call the "team_id" foreign key that because points to the "id" of the associated team.

I tested this in the FastAPI.